### PR TITLE
Remove deprecated bottle :unneeded

### DIFF
--- a/nanoscope.rb
+++ b/nanoscope.rb
@@ -19,8 +19,6 @@ class Nanoscope < Formula
   url "https://github.com/uber/nanoscope/releases/download/0.2.19/nanoscope-0.2.19.zip"
   sha256 "c7e657d014ad62305b38eb65347458ec696a97d771e8cdf0ba6229b5d9b29bee"
 
-  bottle :unneeded
-
   def install
     bin.install "bin/nanoscope"
     bin.install "bin/_nanoscope"


### PR DESCRIPTION
Fixes the warning: 
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the uber/nanoscope tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/uber/homebrew-nanoscope/nanoscope.rb:22
```

Review needed: @Leland-Takamine